### PR TITLE
Add temporary player feature for session-only guests

### DIFF
--- a/index.css
+++ b/index.css
@@ -103,6 +103,33 @@ label {
     width: 100%;
 }
 
+.add-player-form {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.add-player-form input {
+    padding: 0.5rem;
+    border: 1px solid #a4a2a2;
+    border-radius: 0.25rem;
+    font-family: "Roboto Condensed", sans-serif;
+    font-size: 0.875rem;
+}
+
+.add-player-form input[type="text"] {
+    flex: 1;
+}
+
+.add-player-form input[type="number"] {
+    width: 4rem;
+}
+
+.add-player-form button {
+    width: auto;
+    white-space: nowrap;
+}
+
 @media screen and (min-width: 768px) {
     .card {
         width: 50%;

--- a/index.html
+++ b/index.html
@@ -21,6 +21,11 @@
             <h2>Zawodnicy</h2>
             <div class="card-content">
                 <table id="dvTable"></table>
+                <div class="add-player-form">
+                    <input type="text" id="tempPlayerName" placeholder="Imię" />
+                    <input type="number" id="tempPlayerRating" placeholder="Ocena" min="1" max="5" step="0.5" />
+                    <button type="button" id="addTempPlayer">Dodaj</button>
+                </div>
             </div>
         </div>
         <div class="card">

--- a/index.js
+++ b/index.js
@@ -1,6 +1,37 @@
 
 import createTeams from "./createTeams.js";
 
+const addPlayerRow = (player, table) => {
+  var numberOfTeams = document.getElementById("numberOfTeams").value;
+  var row = table.insertRow(-1);
+  var element = document.createElement("input");
+  element.type = "checkbox";
+  element.name = `${player.id}-is-playing`;
+  var cell = row.insertCell(-1);
+  cell.appendChild(element);
+
+  cell = row.insertCell(-1);
+  cell.innerHTML = player.name;
+
+  cell = row.insertCell(-1);
+  cell.innerHTML = player.rating;
+
+  cell = row.insertCell(-1);
+  var select = document.createElement("select");
+  select.name = `${player.id}-team`;
+  var option = document.createElement("option");
+  option.value = 0;
+  option.text = "Dowolna";
+  select.appendChild(option);
+  for (var j = 1; j <= numberOfTeams; j++) {
+    var teamOption = document.createElement("option");
+    teamOption.value = j;
+    teamOption.text = `Drużyna ${j}`;
+    select.appendChild(teamOption);
+  }
+  cell.appendChild(select);
+};
+
 const createPlayersTable = (players) => {
   players = players.sort((a, b) => b.rating - a.rating);
   var table = document.createElement("table");
@@ -21,38 +52,7 @@ const createPlayersTable = (players) => {
   row.appendChild(headerCell);
 
   for (var i = 0; i < players.length; i++) {
-    row = table.insertRow(-1);
-    var element = document.createElement("input");
-    element.type = "checkbox";
-    element.name = `${players[i].id}-is-playing`;
-    var cell = row.insertCell(-1);
-    cell.appendChild(element);
-
-    cell = row.insertCell(-1);
-    cell.innerHTML = players[i].name;
-
-    cell = row.insertCell(-1);
-    cell.innerHTML = players[i].rating;
-
-    //add cell with initial team dropdown options should be either 2 teams or 4 teams depending on selected number of teams
-    cell = row.insertCell(-1);
-    var select = document.createElement("select");
-    select.name = `${players[i].id}-team`;
-    //get selected number of teams
-    var numberOfTeams = document.getElementById("numberOfTeams").value;
-    //add option for no team
-    var option = document.createElement("option");
-    option.value = 0;
-    option.text = "Dowolna";
-    select.appendChild(option);
-    //create options for teams
-    for (var j = 1; j <= numberOfTeams; j++) {
-      var teamOption = document.createElement("option");
-      teamOption.value = j;
-      teamOption.text = `Drużyna ${j}`;
-      select.appendChild(teamOption);
-    }
-    cell.appendChild(select);
+    addPlayerRow(players[i], table);
   }
   var dvTable = document.getElementById("dvTable");
   dvTable.innerHTML = "";
@@ -122,7 +122,21 @@ export const generateTeams = (players, numberOfTeams) => {
 //add error handling and loading indicator
 const response = await fetch("https://opensheet.elk.sh/1YhSB3nBayF7bAMrUyPJPfOnR0QIC1ptdnoqRscz6xYY/tech")
 const json = await response.json()
-const players = json.map(player => ({ id: player.id, name: player.name, rating: Number.parseFloat(player.avg.replace(",", ".")) }));
+let players = json.map(player => ({ id: player.id, name: player.name, rating: Number.parseFloat(player.avg.replace(",", ".")) }));
 
 createPlayersTable(players);
 document.getElementById("submit").addEventListener("click", () => generateTeams(players, parseInt(document.getElementById("numberOfTeams").value)));
+
+document.getElementById("addTempPlayer").addEventListener("click", () => {
+  const nameInput = document.getElementById("tempPlayerName");
+  const ratingInput = document.getElementById("tempPlayerRating");
+  const name = nameInput.value.trim();
+  const rating = parseFloat(ratingInput.value);
+  if (!name || isNaN(rating)) return;
+  const player = { id: `temp-${Date.now()}`, name, rating };
+  players.push(player);
+  const table = document.querySelector("#dvTable table");
+  addPlayerRow(player, table);
+  nameInput.value = "";
+  ratingInput.value = "";
+});


### PR DESCRIPTION
Users can now add guest players (name + rating) via an inline form in the Zawodnicy card without editing the Google Sheet. New players are appended to the existing table without clearing current selections.